### PR TITLE
Add P2P host to PactClientSettings

### DIFF
--- a/PactSharp/Types/PactClientSettings.cs
+++ b/PactSharp/Types/PactClientSettings.cs
@@ -3,13 +3,23 @@ namespace PactSharp.Types;
 public readonly struct PactClientSettings
 {
     public readonly Network Network;
-    public readonly string CustomNetworkEndpoint;
+    public readonly string CustomNetworkRPCEndpoint;
+    public readonly string? CustomNetworkP2PEndpoint;
     public readonly string CustomNetworkId;
 
-    public PactClientSettings(Network network, string customNetworkEndpoint, string customNetworkId)
+    public PactClientSettings(Network network, string customNetworkRpcEndpoint, string customNetworkP2PEndpoint, string customNetworkId)
     {
         Network = network;
-        CustomNetworkEndpoint = customNetworkEndpoint;
+        CustomNetworkRPCEndpoint = customNetworkRpcEndpoint;
+        CustomNetworkP2PEndpoint = customNetworkP2PEndpoint;
+        CustomNetworkId = customNetworkId;
+    }
+
+    public PactClientSettings(Network network, string customNetworkRpcEndpoint, string customNetworkId)
+    {
+        Network = network;
+        CustomNetworkRPCEndpoint = customNetworkRpcEndpoint;
+        CustomNetworkP2PEndpoint = null;
         CustomNetworkId = customNetworkId;
     }
 }


### PR DESCRIPTION
This is an (incomplete) follow-up solution to the P2P mempool problem. (#2)
We can't really force the HttpClient (because of Blazor) to ignore untrusted SSL certs, so applications that want to use these will probably need to do it themselves for now.